### PR TITLE
Fix scheduler caption bug and f-string

### DIFF
--- a/app.py
+++ b/app.py
@@ -218,7 +218,7 @@ elif page == "📅 Calendar View":
 
         st.markdown("### 🔗 Blog Links")
         for _, row in df.iterrows():
-            link = f"[{row['title']}]({f'https://kaveeshagim.github.io/ai-content-creator-agent/{row['slug']}.html'})"
+            link = f"[{row['title']}](https://kaveeshagim.github.io/ai-content-creator-agent/{row['slug']}.html)"
             st.markdown(f"📌 {row['date']}: {link}")
     else:
         st.info("No blogs generated yet.")

--- a/scheduler.py
+++ b/scheduler.py
@@ -10,7 +10,7 @@ def auto_generate_blog():
     first_topic = topics[0].lstrip("1234567890. ").strip()
 
     blog = generate_blog(first_topic)
-    captions = generate_captions(blog)
+    captions = generate_captions(first_topic)
     save_outputs(first_topic, blog, captions)
     print(f"✅ Generated: {first_topic}")
 


### PR DESCRIPTION
## Summary
- fix scheduler to pass topic instead of blog when generating captions
- fix nested f-string in app calendar link

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683fb83bfc8c8331bef170a39f096e02