### PR TITLE
Add env example and update setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# OpenAI API key for generating content
+OPENAI_API_KEY=
+
+# Dev.to API key for posting drafts
+DEVTO_API_KEY=
+
+# Your Dev.to username used in draft URLs
+DEVTO_USERNAME=
+
+# Email address used for alert notifications
+ALERT_EMAIL_USER=
+
+# Password or app password for the alert email account
+ALERT_EMAIL_PASS=

--- a/README.md
+++ b/README.md
@@ -99,7 +99,14 @@
 
 ---
 
-Want to build your own AI-powered publishing assistant?  
+### ⚙️ Setup
+
+1. Copy `.env.example` to `.env` and fill in your API keys.
+2. Install the dependencies with `pip install -r requirements.txt`.
+
+---
+
+Want to build your own AI-powered publishing assistant?
 **Fork this repo and start generating!**
 
 ---


### PR DESCRIPTION
## Summary
- add `.env.example` template for all environment variables
- document how to use it in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fbc1cbe1083318fcdb5538a193306