### PR TITLE
Pass citations to save_outputs

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from langchain.prompts import ChatPromptTemplate
 from langchain.schema import SystemMessage, HumanMessage
 from langchain_core.prompts import ChatPromptTemplate
 from utils import convert_markdown_to_html, generate_rss_feed,add_topic_to_memory, topic_already_exists,generate_blog_metadata,rewrite_topic,summarize_blog,estimate_reading_time,generate_tweet_thread,generate_linkedin_post,create_share_banner,auto_git_push
-from agents import writer_agent, seo_agent, social_agent, editor_agent
+from agents import writer_agent, seo_agent, social_agent, editor_agent, citation_inserter_agent
 
 # load .env file
 load_dotenv()
@@ -155,5 +155,7 @@ if __name__ == "__main__":
     print("\n📣 Social Media Captions:\n")
     print(captions)
 
+    citations = citation_inserter_agent(blog)
+
     #save to local files
-    save_outputs(topic, blog, captions)
+    save_outputs(topic, blog, captions, citations)

--- a/scheduler.py
+++ b/scheduler.py
@@ -2,6 +2,7 @@ import os
 import schedule
 import time
 from main import generate_blog, generate_captions, save_outputs
+from agents import citation_inserter_agent
 from utils import generate_trending_topics
 
 def auto_generate_blog():
@@ -11,7 +12,8 @@ def auto_generate_blog():
 
     blog = generate_blog(first_topic)
     captions = generate_captions(first_topic)
-    save_outputs(first_topic, blog, captions)
+    citations = citation_inserter_agent(blog)
+    save_outputs(first_topic, blog, captions, citations)
     print(f"✅ Generated: {first_topic}")
 
 # Schedule once a day at 9 AM


### PR DESCRIPTION
## Summary
- import citation helper for CLI and scheduler
- include citations when saving outputs in main script
- include citations in scheduled post generation

## Testing
- `OPENAI_API_KEY=dummy python main.py <<'EOF'
hello
EOF` *(fails: Connection error)*
- `OPENAI_API_KEY=dummy python scheduler.py > /tmp/scheduler.log 2>&1 & sleep 2; pkill -f scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_683fca5c0c508331aebdafae989a4a55