### PR TITLE
Add DALL-E banner generation option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # OpenAI API key for generating content
 OPENAI_API_KEY=
+# OpenAI API key for DALL-E image generation
+DALLE_API_KEY=
 
 # Dev.to API key for posting drafts
 DEVTO_API_KEY=

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from langchain_openai import ChatOpenAI
 from langchain.prompts import ChatPromptTemplate
 from langchain.schema import SystemMessage, HumanMessage
 from langchain_core.prompts import ChatPromptTemplate
-from utils import convert_markdown_to_html, generate_rss_feed,add_topic_to_memory, topic_already_exists,generate_blog_metadata,rewrite_topic,summarize_blog,estimate_reading_time,generate_tweet_thread,generate_linkedin_post,create_share_banner,auto_git_push
+from utils import convert_markdown_to_html, generate_rss_feed,add_topic_to_memory, topic_already_exists,generate_blog_metadata,rewrite_topic,summarize_blog,estimate_reading_time,generate_tweet_thread,generate_linkedin_post,create_share_banner,create_dalle_banner,auto_git_push
 from agents import writer_agent, seo_agent, social_agent, editor_agent, citation_inserter_agent
 
 # load .env file
@@ -79,7 +79,10 @@ def save_outputs(topic, blog, captions,citations):
     metadata["reading_time"] = estimate_reading_time(blog)
     metadata["tweet_thread"] = generate_tweet_thread(blog)
     metadata["linkedin_post"] = generate_linkedin_post(blog)
-    metadata["share_banner"] = create_share_banner(title=topic, slug=slug)
+    banner_path = create_dalle_banner(title=topic, slug=slug)
+    if not banner_path:
+        banner_path = create_share_banner(title=topic, slug=slug)
+    metadata["share_banner"] = banner_path
     metadata["social_posts"] = socials
 
     os.makedirs("metadata", exist_ok=True)

--- a/utils.py
+++ b/utils.py
@@ -10,6 +10,10 @@ from xml.dom.minidom import parseString
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 from PIL import Image, ImageDraw, ImageFont
+from dotenv import load_dotenv
+import openai
+import requests
+import base64
 
 TOPIC_MEMORY_FILE = "memory/topics.json"
 
@@ -300,6 +304,35 @@ def create_share_banner(title, slug):
 
     path = f"banners/{slug}.png"
     img.save(path)
+    return path
+
+def create_dalle_banner(title, slug):
+    """Generate a banner image using OpenAI's DALL-E API."""
+    load_dotenv()
+    api_key = os.getenv("DALLE_API_KEY") or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("OpenAI API key not provided.")
+
+    client = openai.OpenAI(api_key=api_key)
+    prompt = f"Social media banner with the text '{title}' on a clean dark background"
+
+    try:
+        response = client.images.generate(
+            model="dall-e-3",
+            prompt=prompt,
+            n=1,
+            size="1024x576",
+            response_format="b64_json",
+        )
+        image_data = response.data[0].b64_json
+    except Exception as e:
+        print(f"DALL-E generation failed: {e}")
+        return None
+
+    os.makedirs("banners", exist_ok=True)
+    path = f"banners/{slug}_dalle.png"
+    with open(path, "wb") as f:
+        f.write(base64.b64decode(image_data))
     return path
 
 def auto_git_push():


### PR DESCRIPTION
## Summary
- add `DALLE_API_KEY` to `.env.example`
- create `create_dalle_banner` using OpenAI's DALL-E API
- use new banner generator in `save_outputs`

## Testing
- `python -m py_compile main.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_683fe26ac18c8331927e4acb0d0e85a8