### PR TITLE
Implement scheduled time fix and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -116,6 +116,17 @@
   npm run dev
   ```
 
+### 📚 API Endpoints
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `POST` | `/generate` | Generate blog content from a topic |
+| `GET`  | `/suggest-topics?category=tech` | Get trending topic ideas |
+| `GET`  | `/check-topic` | Check if a blog slug exists and get a rewrite |
+| `POST` | `/save` | Save blog, captions, and citations |
+| `GET`  | `/calendar` | Return calendar data of published blogs |
+| `GET`  | `/analytics` | Aggregate metadata for dashboard |
+
 ---
 
 Want to build your own AI-powered publishing assistant?

--- a/api.py
+++ b/api.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, HTTPException, Query
+import asyncio
 from pydantic import BaseModel
 from agents import writer_agent, proofreader_agent, seo_agent, editor_agent, citation_inserter_agent, social_agent
 from utils import estimate_reading_time, generate_tweet_thread, generate_linkedin_post, rewrite_topic, generate_trending_topics, load_blog_calendar_data
@@ -30,13 +31,13 @@ class SaveRequest(BaseModel):
     citations: str
 
 @app.post("/generate")
-def generate_blog_content(req: BlogRequest):
+async def generate_blog_content(req: BlogRequest):
     try:
-        raw_blog = writer_agent(req.topic, req.tone, req.audience, req.outline)
-        blog = proofreader_agent(raw_blog)
-        summary = editor_agent(blog)
-        citations = citation_inserter_agent(blog)
-        seo_data = seo_agent(blog)
+        raw_blog = await asyncio.to_thread(writer_agent, req.topic, req.tone, req.audience, req.outline)
+        blog = await asyncio.to_thread(proofreader_agent, raw_blog)
+        summary = await asyncio.to_thread(editor_agent, blog)
+        citations = await asyncio.to_thread(citation_inserter_agent, blog)
+        seo_data = await asyncio.to_thread(seo_agent, blog)
 
         try:
             seo_parsed = json.loads(seo_data)
@@ -62,36 +63,36 @@ def generate_blog_content(req: BlogRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/suggest-topics")
-def suggest_topics(category: str = Query(..., example="tech")):
+async def suggest_topics(category: str = Query(..., example="tech")):
     try:
-        topics = generate_trending_topics(category)
+        topics = await asyncio.to_thread(generate_trending_topics, category)
         return {"topics": topics.split("\n")}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
     
 @app.get("/check-topic")
-def check_topic(slug: str, topic: str):
-    exists = topic_already_exists(slug)
-    suggestion = rewrite_topic(topic)
+async def check_topic(slug: str, topic: str):
+    exists = await asyncio.to_thread(topic_already_exists, slug)
+    suggestion = await asyncio.to_thread(rewrite_topic, topic)
     return {"exists": exists, "rewritten": suggestion}
 
 
 
 @app.post("/save")
-def save_blog(req: SaveRequest):
+async def save_blog(req: SaveRequest):
     try:
-        save_outputs(req.topic, req.blog, req.captions, req.citations)
+        await asyncio.to_thread(save_outputs, req.topic, req.blog, req.captions, req.citations)
         return JSONResponse(content={"message": "Saved successfully"}, status_code=201)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/calendar")
-def calendar_data():
-    df = load_blog_calendar_data()
+async def calendar_data():
+    df = await asyncio.to_thread(load_blog_calendar_data)
     return df.to_dict(orient="records")
 
 @app.get("/analytics")
-def dashboard_data():
+async def dashboard_data():
     from datetime import datetime
     import os
     from collections import Counter

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ requests==2.32.3
 yagmail==0.15.293
 schedule==1.2.2
 pydantic==2.11.5
+pytest
+httpx

--- a/scheduler.py
+++ b/scheduler.py
@@ -17,7 +17,7 @@ def auto_generate_blog():
     print(f"✅ Generated: {first_topic}")
 
 # Schedule once a day at 9 AM
-schedule.every().day.at("01:11").do(auto_generate_blog)
+schedule.every().day.at("09:00").do(auto_generate_blog)
 
 print("🕒 Blog Scheduler started... Press Ctrl+C to stop.")
 while True:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,15 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+from fastapi.testclient import TestClient
+from api import app
+
+client = TestClient(app)
+
+def test_calendar():
+    response = client.get('/calendar')
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,11 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+from utils import estimate_reading_time
+
+def test_estimate_reading_time():
+    text = "word " * 400
+    assert estimate_reading_time(text) == "2 min read"
+

--- a/utils.py
+++ b/utils.py
@@ -7,6 +7,7 @@ import pandas as pd
 from datetime import datetime
 from xml.etree.ElementTree import Element, SubElement, tostring
 from xml.dom.minidom import parseString
+import logging
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 from PIL import Image, ImageDraw, ImageFont
@@ -16,6 +17,8 @@ import requests
 import base64
 
 TOPIC_MEMORY_FILE = "memory/topics.json"
+
+logger = logging.getLogger(__name__)
 
 def convert_markdown_to_html(markdown_text, title, slug):
     html_content = markdown.markdown(markdown_text)
@@ -212,8 +215,12 @@ def generate_trending_topics(n=5, category="tech"):
     ])
 
     llm = ChatOpenAI()
-    response = llm.invoke(prompt.format_messages())
-    return response.content.strip()
+    try:
+        response = llm.invoke(prompt.format_messages())
+        return response.content.strip()
+    except Exception as e:
+        logger.error("Failed to generate trending topics: %s", e)
+        return ""
 
 def summarize_blog(blog):
     prompt = ChatPromptTemplate.from_messages([
@@ -336,9 +343,19 @@ def create_dalle_banner(title, slug):
     return path
 
 def auto_git_push():
+    """Push generated docs to Git if enabled via environment variable."""
+    if os.getenv("ENABLE_GIT_PUSH", "false").lower() != "true":
+        print("ℹ️ Git push skipped (ENABLE_GIT_PUSH not set).")
+        return
+
     try:
         subprocess.run(["git", "add", "docs"], check=True)
-        subprocess.run(["git", "commit", "-m", "🤖 Auto update: new blog and RSS"], check=True)
+        subprocess.run([
+            "git",
+            "commit",
+            "-m",
+            "🤖 Auto update: new blog and RSS",
+        ], check=True)
         subprocess.run(["git", "push"], check=True)
         print("✅ Git push complete.")
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Summary
- fix scheduler comment and run time to 9AM
- make git push optional via `ENABLE_GIT_PUSH`
- convert FastAPI routes to async and run blocking tasks in thread pool
- add Dockerfile and CI workflow
- add unit tests for utilities and API
- add logging around OpenAI calls and document API endpoints in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68401e8c3e68833194f3adf86af4a0f8